### PR TITLE
Remove BITLY_ settings from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Additional Information
 ======================
 You will need to create a file called "settings.py" containing the following:
 ```
-BITLY_LOGIN = ""
-BITLY_APIKEY = ""
 CONSUMER_KEY = ""
 CONSUMER_SECRET = ""
 ```


### PR DESCRIPTION
Automatic bit.ly shortening was removed, so this shouldn't be documented anymore
